### PR TITLE
Set minimum python required to 3.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,6 @@ setup(
         "Topic :: Scientific/Engineering :: Mathematics",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 3"]
+        "Programming Language :: Python :: 3"],
+    python_requires=">=3.5",
 )


### PR DESCRIPTION
- Python 3 required because unicode used in trianglesolver.py without utf8 marker
- math.isclose added in python 3.5